### PR TITLE
Add support for ActiveSupport 6.1

### DIFF
--- a/lib/reactive_shipping/version.rb
+++ b/lib/reactive_shipping/version.rb
@@ -1,3 +1,3 @@
 module ReactiveShipping
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/reactive_shipping.gemspec
+++ b/reactive_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 6.1")
+  s.add_dependency("activesupport", ">= 4.2", "< 6.2")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 


### PR DESCRIPTION
Add support for ActiveSupport 6.1:

* Add `s.add_dependency("activesupport", ">= 4.2", "< 6.2")` to `gemspec`
* Bump version to `3.0.1`